### PR TITLE
feat: Add PostgreSQL and MySQL database support

### DIFF
--- a/configs/userConfig.toml
+++ b/configs/userConfig.toml
@@ -5,6 +5,7 @@ chain = "coston"
 protocol_id = 200
 
 [db]
+type = "mysql"
 host = "localhost"
 port = 3306
 database = "flare_ftso_indexer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "A Python implementation of the Flare Data Connector client."
 dependencies = [
     "tomli",
     "mysql-connector-python",
+    "psycopg2-binary",
     "fastapi",
     "uvicorn",
     "eth-abi",

--- a/src/collector.py
+++ b/src/collector.py
@@ -1,32 +1,25 @@
 import asyncio
-import mysql.connector
 from typing import Any, Dict
 
 from src.config import Config
+from src.database import DatabaseConnector
 from src.shared import DataPipes
 
 class Collector:
     def __init__(self, config: Config, data_pipes: DataPipes):
         self.config = config
         self.data_pipes = data_pipes
+        self.db_connector = None
         self.db_connection = None
 
     async def connect_to_db(self):
         """Establishes a connection to the database."""
         db_config = self.config.database_config
+        self.db_connector = DatabaseConnector(db_config)
         try:
-            self.db_connection = mysql.connector.connect(
-                host=db_config["host"],
-                port=db_config["port"],
-                user=db_config["username"],
-                password=db_config["password"],
-                database=db_config["database"],
-            )
-            print("Successfully connected to the database.")
-        except mysql.connector.Error as err:
-            print(f"Error connecting to database: {err}")
-            # In a real application, you'd want more robust error handling
-            # and retry logic here.
+            self.db_connection = self.db_connector.connect()
+        except Exception as e:
+            print(f"Error connecting to database: {e}")
             raise
 
     async def run(self, ctx: Dict[str, Any]):
@@ -53,7 +46,6 @@ class Collector:
                 await asyncio.sleep(10) # Fetch data every 10 seconds
             except asyncio.CancelledError:
                 print("Collector task cancelled.")
-                if self.db_connection and self.db_connection.is_connected():
-                    self.db_connection.close()
-                    print("Database connection closed.")
+                if self.db_connector:
+                    self.db_connector.close()
                 break

--- a/src/config.py
+++ b/src/config.py
@@ -37,8 +37,13 @@ class Config:
         """
         config = self.user_config.get("db", {})
 
+        db_type = os.environ.get("DB_TYPE", config.get("type", "mysql"))
+        config["type"] = db_type
+
+        default_port = 5432 if db_type == "postgres" else 3306
+
         config["host"] = os.environ.get("DB_HOST", config.get("host"))
-        config["port"] = int(os.environ.get("DB_PORT", config.get("port", 3306)))
+        config["port"] = int(os.environ.get("DB_PORT", config.get("port", default_port)))
         config["database"] = os.environ.get("DB_DATABASE", config.get("database"))
         config["username"] = os.environ.get("DB_USERNAME", config.get("username"))
         config["password"] = os.environ.get("DB_PASSWORD", config.get("password"))

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,55 @@
+import mysql.connector
+import psycopg2
+from typing import Any, Dict
+
+class DatabaseConnector:
+    def __init__(self, db_config: Dict[str, Any]):
+        self.db_config = db_config
+        self.connection = None
+
+    def connect(self):
+        """Establishes a connection to the database based on the type."""
+        db_type = self.db_config.get("type")
+        if db_type == "mysql":
+            self._connect_mysql()
+        elif db_type == "postgres":
+            self._connect_postgres()
+        else:
+            raise ValueError(f"Unsupported database type: {db_type}")
+        return self.connection
+
+    def _connect_mysql(self):
+        """Connects to a MySQL database."""
+        try:
+            self.connection = mysql.connector.connect(
+                host=self.db_config["host"],
+                port=self.db_config["port"],
+                user=self.db_config["username"],
+                password=self.db_config["password"],
+                database=self.db_config["database"],
+            )
+            print("Successfully connected to MySQL database.")
+        except mysql.connector.Error as err:
+            print(f"Error connecting to MySQL database: {err}")
+            raise
+
+    def _connect_postgres(self):
+        """Connects to a PostgreSQL database."""
+        try:
+            self.connection = psycopg2.connect(
+                host=self.db_config["host"],
+                port=self.db_config["port"],
+                user=self.db_config["username"],
+                password=self.db_config["password"],
+                dbname=self.db_config["database"],
+            )
+            print("Successfully connected to PostgreSQL database.")
+        except psycopg2.Error as err:
+            print(f"Error connecting to PostgreSQL database: {err}")
+            raise
+
+    def close(self):
+        """Closes the database connection."""
+        if self.connection:
+            self.connection.close()
+            print("Database connection closed.")


### PR DESCRIPTION
This commit introduces a database abstraction layer to support both PostgreSQL and MySQL as backends.

Key changes:
- Added `psycopg2-binary` dependency for PostgreSQL support.
- Created `src/database.py` with a `DatabaseConnector` class to manage database connections.
- Updated `src/config.py` to allow specifying the database `type` (mysql or postgres) in the configuration.
- Refactored `src/collector.py` to use the new `DatabaseConnector`.
- Updated `configs/userConfig.toml` to include the new `type` field.