### PR TITLE
feat: Expose Prometheus port for external access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,5 +39,15 @@ services:
       retries: 5
       start_period: 30s
 
+  prometheus:
+    image: prom/prometheus:v2.30.3
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    depends_on:
+      - app
+    restart: on-failure
+
 volumes:
   mysql_data:

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'fdc-client'
+    static_configs:
+      - targets: ['app:8080']


### PR DESCRIPTION
This commit updates the Docker Compose configuration to allow for external access to the Prometheus endpoint.

- A `prometheus` service has been added to `docker-compose.yml`, which exposes port 9090 for external access.
- A new `prometheus.yml` configuration file has been created in `docker/prometheus/` to configure the Prometheus service to scrape metrics from the application.
- The application's configuration was verified to ensure the Prometheus metrics endpoint is enabled.